### PR TITLE
Add issue templates and community health files (2026.2.1)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# Contributing standards
+
+Conventions for issues, branches, commits, and pull requests in Turnstil. The
+templates in `.github/` enforce most of this — this is the why.
+
+## Issues
+
+- Use the Bug report or Feature request form (blank issues are disabled).
+- One issue = one problem or one request.
+- Security issues go through a private advisory, never a public issue.
+- Never paste secrets, keys, or attendee personal data.
+
+## Branches
+
+Short, prefixed, kebab-case off `main`:
+
+```
+fix/checkin-double-scan
+feat/waitlist-promotion
+docs/proxy-deployment
+chore/bump-2026.2.1
+```
+
+## Commits
+
+- Plain style. Short subject with the version in parens when it's a release,
+  e.g. `Add QR re-scan grace window on check-in (2026.2.1)`.
+- One sentence per change on its own line in the body; no bullet lists.
+- **No AI / Co-Authored-By trailers.**
+- Don't commit secrets, keys, or attendee data.
+
+## Pull requests
+
+- Fill in the PR template, including the proposed commit message.
+- Tests must pass: `python manage.py test`.
+- Run `makemigrations` if a model changed, and commit the migration.
+
+## Releases
+
+Turnstil's version lives in git tags. A release is a `vYYYY.N.P` tag on `main`
+after the PR merges.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,68 @@
+name: Bug report
+description: Something in Turnstil isn't working as expected
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug. One issue = one problem. Never paste secrets,
+        API keys, or attendee personal data — redact before posting.
+  - type: input
+    id: version
+    attributes:
+      label: Turnstil version
+      description: Release tag (e.g. v2026.2.0) or the deployed commit SHA.
+      placeholder: "v2026.2.0"
+    validations:
+      required: true
+  - type: dropdown
+    id: component
+    attributes:
+      label: Area
+      options:
+        - Events
+        - Registration
+        - Check-in / QR scanning
+        - Contact sharing
+        - Admin portal
+        - REST API
+        - Civil SSO
+        - Email / notifications
+        - Deployment (Docker / proxy / CSRF)
+        - Other
+    validations:
+      required: true
+  - type: dropdown
+    id: deployment
+    attributes:
+      label: Deployment
+      options:
+        - Docker
+        - Manual / from source
+        - Other
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What you did, what you expected, and what actually happened.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs / traceback
+      description: Django logs or the traceback. Redact secrets and attendee data.
+      render: shell
+  - type: input
+    id: env
+    attributes:
+      label: Browser / device (for UI or scanner bugs)
+      placeholder: "iOS 18 Safari · iPhone 14"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/Susquehanna-Syntax/Turnstil/security/advisories/new
+    about: Disclose security issues privately. Never open a public issue for a vulnerability.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,40 @@
+name: Feature request
+description: Suggest an improvement to Turnstil
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        One request per issue. Describe the problem before the solution — it
+        helps us find the best fix, which isn't always the one first imagined.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / use case
+      description: What are you trying to do, and what's missing or awkward today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Events
+        - Registration
+        - Check-in / QR scanning
+        - Contact sharing
+        - Admin portal
+        - REST API
+        - Civil SSO
+        - Email / notifications
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy
+
+Turnstil handles event registration and attendee contact data, so we ask that
+security problems be disclosed privately.
+
+## Reporting a vulnerability
+
+**Do not open a public issue, PR, or discussion for a security problem.**
+
+Report it privately through GitHub:
+
+1. Go to the repository's **Security** tab → **Report a vulnerability**
+   (<https://github.com/Susquehanna-Syntax/Turnstil/security/advisories/new>).
+2. Include the details below.
+
+This opens a private advisory visible only to you and the maintainers.
+
+Please include:
+
+- Affected area (a specific view/endpoint, QR check-in, the API) and version.
+- Steps to reproduce or a proof of concept.
+- Impact — what an attacker can read, change, or do.
+- Any suggested remediation.
+
+## Scope
+
+In scope: authentication and session handling, registration and check-in
+integrity, QR token/code handling, attendee-data access control, the REST API,
+and CSRF/host handling.
+
+Out of scope: findings that require a pre-compromised host or admin account,
+and issues in third-party dependencies without a Turnstil-specific exploit path.
+
+We aim to acknowledge reports within a few days and to coordinate a fix and
+disclosure timeline with you.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,37 @@
+## Summary
+
+<!-- One or two sentences: what this changes and why. -->
+
+## Type
+
+- [ ] Bug fix
+- [ ] Feature
+- [ ] Refactor / cleanup
+- [ ] Docs
+
+## Proposed commit message
+
+<!--
+Plain style: short subject with the version in parens, one sentence per change
+on its own line, no bullet lists, no AI / Co-Authored-By trailer.
+e.g. "Add QR re-scan grace window on check-in (2026.2.1)"
+-->
+
+```
+```
+
+## Checklist
+
+- [ ] Tests pass: `python manage.py test`
+- [ ] Migrations added if any model changed (`makemigrations`)
+- [ ] Version tag planned if this is a release
+- [ ] No AI / Co-Authored-By attribution in commits
+- [ ] No secrets, keys, or attendee personal data committed
+
+## Testing
+
+<!-- What you ran and what you observed. -->
+
+## Screenshots
+
+<!-- UI changes only. -->


### PR DESCRIPTION
Brings the Vigil-style .github set (bug/feature templates, config, PR template, CONTRIBUTING, SECURITY) to Turnstil, adapted to the event-management domain. Tag `v2026.2.1` after merge